### PR TITLE
Implement #35: Maid/Trove Cleanup Pattern

### DIFF
--- a/src/shared/Maid.luau
+++ b/src/shared/Maid.luau
@@ -1,0 +1,82 @@
+--!strict
+--[[
+    Maid - Cleanup module to prevent memory leaks
+    Properly destroys connections, instances, and tasks when cleanup is called.
+    Based on BRicey Maid, Trove, Janitor cleanup modules tutorial
+
+    Usage:
+        local maid = Maid.new()
+
+        -- Track a connection
+        maid:give(part.Touched:Connect(function(hit)
+            print("Touched by", hit.Name)
+        end))
+
+        -- Track a spawned instance
+        local effect = Instance.new("Part")
+        effect.Parent = workspace
+        maid:give(effect)
+
+        -- Track a running task (thread)
+        maid:give(task.spawn(function()
+            while true do
+                task.wait(1)
+                print("Running...")
+            end
+        end))
+
+        -- When done with everything
+        maid:destroy()  -- All connections, instances, and tasks cleaned up
+]]
+
+local Maid = {}
+Maid.__index = Maid
+
+export type Task = RBXScriptConnection | Instance | () -> () | thread
+export type Maid = typeof(setmetatable({} :: { _tasks: { Task } }, Maid))
+
+--- Creates a new Maid instance for tracking cleanup tasks
+function Maid.new(): Maid
+    local self = setmetatable({
+        _tasks = {} :: { Task },
+    }, Maid)
+    return self
+end
+
+--- Adds a task to be cleaned up later
+--- Returns the task so it can be used inline
+function Maid:give<T>(taskToTrack: T): T
+    table.insert(self._tasks, taskToTrack :: any)
+    return taskToTrack
+end
+
+--- Cleans up all tracked tasks
+--- Connections are disconnected, Instances are destroyed, functions are called, threads are cancelled
+function Maid:cleanup(): ()
+    for _, taskItem in self._tasks do
+        local taskType = typeof(taskItem)
+
+        if taskType == "RBXScriptConnection" then
+            (taskItem :: RBXScriptConnection):Disconnect()
+        elseif taskType == "Instance" then
+            (taskItem :: Instance):Destroy()
+        elseif taskType == "function" then
+            (taskItem :: () -> ())()
+        elseif taskType == "thread" then
+            task.cancel(taskItem :: thread)
+        end
+    end
+    table.clear(self._tasks)
+end
+
+--- Alias for cleanup - destroys the maid and all tracked tasks
+function Maid:destroy(): ()
+    self:cleanup()
+end
+
+--- Returns the number of tasks currently being tracked
+function Maid:getTaskCount(): number
+    return #self._tasks
+end
+
+return Maid


### PR DESCRIPTION
Closes #35

## Summary
- Added `Maid` module to `src/shared/Maid.luau` for tracking and cleaning up resources
- Supports cleanup of RBXScriptConnections, Instances, functions, and threads
- Prevents memory leaks from undisconnected connections, orphaned tasks, and accumulated instances
- Follows BRicey's Maid/Trove/Janitor cleanup pattern tutorial

## Changes
- `src/shared/Maid.luau`: New cleanup utility module with:
  - `Maid.new()` - Creates a new Maid instance
  - `Maid:give(task)` - Adds a task to be cleaned up (returns task for inline use)
  - `Maid:cleanup()` - Cleans up all tracked tasks
  - `Maid:destroy()` - Alias for cleanup
  - `Maid:getTaskCount()` - Returns number of tracked tasks
  - Full type annotations for strict mode

## Test Plan
1. Connect to Rojo in Roblox Studio
2. Create a test script that uses Maid:
   ```lua
   local Maid = require(game.ReplicatedStorage.shared.Maid)
   local maid = Maid.new()
   
   -- Test connection cleanup
   maid:give(workspace.ChildAdded:Connect(function() end))
   print("Tasks before cleanup:", maid:getTaskCount()) -- Should print 1
   
   maid:destroy()
   print("Tasks after cleanup:", maid:getTaskCount()) -- Should print 0
   ```
3. Verify no memory growth over time when repeatedly creating and destroying maids
4. Check Output window for any errors

## Checklist
- [x] Uses `.luau` extension
- [x] Follows `--!strict` typing
- [x] Follows coding standards from CLAUDE.md
- [x] Module is ready for use by NPC AI, projectiles, player events, and visual effects