### PR TITLE
Implement #54: Restructure to BRicey Module Pattern - Entry Points + ModuleScripts

### DIFF
--- a/src/client/MusicManager.luau
+++ b/src/client/MusicManager.luau
@@ -318,15 +318,4 @@ function MusicManager:destroy(): ()
     self._maid:destroy()
 end
 
--- Create singleton instance and start playing
-local musicManager = MusicManager.new()
-
--- Start playing the soundtrack playlist
-musicManager:playPlaylist(false) -- Sequential playback
-
--- Expose the manager globally for debugging/other scripts
-_G.MusicManager = musicManager
-
-print("[MusicManager] Initialized - Playing Roman soundtrack")
-
 return MusicManager

--- a/src/client/init.client.luau
+++ b/src/client/init.client.luau
@@ -1,1 +1,16 @@
-print("Hello world, from client!")
+--!strict
+-- Client Entry Point - Bootstraps all client systems
+
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+-- Wait for shared modules to be available
+local Shared = ReplicatedStorage:WaitForChild("Shared")
+
+-- Require and initialize client modules
+local MusicManager = require(script.MusicManager)
+
+-- Bootstrap music
+local musicManager = MusicManager.new()
+musicManager:playPlaylist(false) -- Sequential playback
+
+print("[Client] All systems initialized")

--- a/src/server/TerrainManager.luau
+++ b/src/server/TerrainManager.luau
@@ -190,27 +190,4 @@ function TerrainManager:getCFrameAlignedToTerrain(x: number, z: number): CFrame
     return TerrainUtils.getCFrameAlignedToTerrain(self.terrain, x, z)
 end
 
--- Initialize and generate terrain on server start
-local function init()
-    print("[TerrainManager] Initializing...")
-
-    local manager = TerrainManager.new({
-        size = TERRAIN_SIZE,
-        baseHeight = BASE_HEIGHT,
-        heightAmplitude = HEIGHT_AMPLITUDE,
-        noiseScale = NOISE_SCALE,
-    })
-
-    manager:generate()
-
-    -- Store reference for other scripts
-    local terrainManagerValue = Instance.new("ObjectValue")
-    terrainManagerValue.Name = "TerrainManager"
-    terrainManagerValue.Parent = ReplicatedStorage
-
-    print("[TerrainManager] Initialization complete!")
-end
-
-init()
-
 return TerrainManager

--- a/src/server/init.server.luau
+++ b/src/server/init.server.luau
@@ -1,1 +1,21 @@
-print("Hello world, from server!")
+--!strict
+-- Server Entry Point - Bootstraps all server systems
+
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+-- Wait for shared modules to be available
+local Shared = ReplicatedStorage:WaitForChild("Shared")
+
+-- Require and initialize server modules
+local TerrainManager = require(script.TerrainManager)
+
+-- Bootstrap terrain
+local terrainManager = TerrainManager.new({
+    size = 512,
+    baseHeight = 20,
+    heightAmplitude = 40,
+    noiseScale = 0.01,
+})
+terrainManager:generate()
+
+print("[Server] All systems initialized")


### PR DESCRIPTION
Closes #54

## Summary
Restructured the codebase to follow the BRicey module pattern where entry points (`init.server.luau`, `init.client.luau`) bootstrap the system by requiring and initializing ModuleScripts.

## Changes
- `src/server/TerrainManager.server.luau` → `src/server/TerrainManager.luau`: Renamed to proper ModuleScript extension, removed auto-executing `init()` call at bottom
- `src/client/MusicManager.client.luau` → `src/client/MusicManager.luau`: Renamed to proper ModuleScript extension, removed auto-executing singleton code at bottom
- `src/server/init.server.luau`: Updated to require TerrainManager and call `TerrainManager.new()` + `generate()`
- `src/client/init.client.luau`: Updated to require MusicManager and call `MusicManager.new()` + `playPlaylist()`

## Test Plan
After `rojo serve`, Output should show:
```
[Server] All systems initialized
[TerrainManager] Starting terrain generation...
[TerrainManager] Terrain generated in X.XX seconds
[Client] All systems initialized
```

And you should see:
- Terrain: 512x512 undulating hills
- Music: Roman soundtrack playing

## BRicey Pattern Checklist
- [x] ModuleScripts use .luau extension
- [x] Entry point updated to require/initialize module
- [x] No auto-executing code in ModuleScripts
- [x] ModuleScripts return their table

🤖 Generated with [Claude Code](https://claude.com/claude-code)