### PR TITLE
Fix #100: Raise fountain water level to near the rim

### DIFF
--- a/src/server/WaterPool.luau
+++ b/src/server/WaterPool.luau
@@ -15,7 +15,7 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local WaterPool = {}
 WaterPool.__index = WaterPool
-WaterPool.VERSION = "2.1.0"
+WaterPool.VERSION = "2.2.0"
 
 -- Type definitions
 export type PoolConfig = {
@@ -64,8 +64,9 @@ function WaterPool:build(): Folder
     -- CRITICAL: Query terrain height at center position
     local terrainY = self.terrainUtils.getHeightAt(self.terrain, pos.X, pos.Z)
     local poolBottom = terrainY - size.Y
-    local waterSurface = terrainY -- Water surface at terrain level
-    local wallTop = terrainY + rimHeight -- Walls extend above water
+    local wallTop = terrainY + rimHeight -- Walls extend above terrain
+    -- Water surface should be near the rim (1-2 studs below wall top) so fountain looks full
+    local waterSurface = wallTop - 1 -- Water fills to 1 stud below rim
 
     -- Create folder for organization
     local folderName = config.name or string.format("WaterPool_%.0f_%.0f", pos.X, pos.Z)
@@ -134,7 +135,7 @@ function WaterPool:build(): Folder
     local clearRegion = Region3.new(clearMinCorner, clearMaxCorner)
     self.terrain:FillRegion(clearRegion, 4, Enum.Material.Air)
 
-    -- Fill water region only (from pool bottom to water surface)
+    -- Fill water region only (from pool bottom to water surface near rim)
     local waterMinCorner = Vector3.new(
         pos.X - size.X / 2,
         poolBottom,
@@ -142,7 +143,7 @@ function WaterPool:build(): Folder
     )
     local waterMaxCorner = Vector3.new(
         pos.X + size.X / 2,
-        waterSurface - 0.1, -- Slightly below terrain surface
+        waterSurface, -- Water fills to near the rim so fountain looks full
         pos.Z + size.Z / 2
     )
     local waterRegion = Region3.new(waterMinCorner, waterMaxCorner)

--- a/tests/server/WaterPool.spec.luau
+++ b/tests/server/WaterPool.spec.luau
@@ -122,6 +122,12 @@ describe("WaterPool", function()
         expect(string.find(moduleSource, "Enum.Material.Air", 1, true)).toNotBeNil()
     end)
 
+    it("should fill water to near the rim so fountain looks full", function()
+        -- Bug fix #100: Water surface should be near wall top, not at terrain level
+        -- waterSurface = wallTop - 1 (1 stud below rim)
+        expect(string.find(moduleSource, "wallTop - 1", 1, true)).toNotBeNil()
+    end)
+
     it("should not have auto-executing code at module end", function()
         -- Check that module ends with return statement, not function calls
         local lines = {}


### PR DESCRIPTION
Closes #100

## Summary
- Fixed water level calculation so fountains appear full
- Water now fills to 1 stud below the rim instead of terrain level

## Changes
- `src/server/WaterPool.luau`: Changed `waterSurface` calculation from `terrainY` to `wallTop - 1`, bumped version to 2.2.0
- `tests/server/WaterPool.spec.luau`: Added test to verify water fills near the rim

## Test Plan
1. Run `rojo serve` and sync to Roblox Studio
2. Observe fountains - water surface should be visible at or near the rim
3. Water should appear "full" not partially filled

## BRicey Pattern Checklist
- [x] ModuleScripts use .luau extension
- [x] Entry point already requires/initializes module (no changes needed)
- [x] No auto-executing code in ModuleScripts
- [x] Objects adapt to terrain height

🤖 Generated with [Claude Code](https://claude.com/claude-code)