### PR TITLE
Fix #115: Increase basin fountain size from 5x5 to 8x8 studs

### DIFF
--- a/src/shared/FountainConfig.luau
+++ b/src/shared/FountainConfig.luau
@@ -3,7 +3,7 @@
     FountainConfig - Definitions for Roman fountain types and placements
 
     Fountain Types (from smallest to largest):
-    - Basin: Tiny (5x5), street corners
+    - Basin: Small (8x8), street corners
     - Impluvium: Small (10x10), Domus atriums (player-built)
     - PublicFountain: Medium (20x20), plazas, intersections
     - Nymphaeum: Large (30x15), Forum, civic areas
@@ -16,7 +16,7 @@
 ]]
 
 local FountainConfig = {}
-FountainConfig.VERSION = "1.1.0"
+FountainConfig.VERSION = "1.2.0"
 
 -- Roman color palette
 FountainConfig.COLORS = {
@@ -42,7 +42,7 @@ export type FountainTypeConfig = {
 FountainConfig.TYPES = {
     basin = {
         name = "Basin",
-        size = Vector3.new(5, 4, 5), -- 5x5 footprint, 4 studs deep
+        size = Vector3.new(8, 5, 8), -- 8x8 footprint, 5 studs deep
         wallMaterial = Enum.Material.Marble,
         wallColor = FountainConfig.COLORS.MARBLE_WHITE,
         wallThickness = 1,


### PR DESCRIPTION
Closes #115

## Summary
- Increased smallest fountain (basin) size from 5x5 to 8x8 studs
- Increased basin depth from 4 to 5 studs for better visual presence

## Changes
- `src/shared/FountainConfig.luau`: Updated basin size from `Vector3.new(5, 4, 5)` to `Vector3.new(8, 5, 8)`
- Bumped version from 1.1.0 to 1.2.0

## Test Plan
1. Run `rojo serve` and sync to Roblox Studio
2. Play the game and observe basin fountains (WestRoad_Basin, EastRoad_Basin, NorthWest_Basin, NorthEast_Basin)
3. Verify basins are now 8x8 studs and visually noticeable as landmarks

## BRicey Pattern Checklist
- [x] ModuleScripts use .luau extension
- [x] Entry point updated to require/initialize module (no changes needed - config only)
- [x] No auto-executing code in ModuleScripts
- [x] ModuleScripts return their table