### PR TITLE
Fix #113: River water overwritten by TerrainMaterials

### DIFF
--- a/src/server/TerrainMaterials.luau
+++ b/src/server/TerrainMaterials.luau
@@ -22,7 +22,7 @@ local TerrainUtils = require(Shared:WaitForChild("TerrainUtils"))
 
 local TerrainMaterials = {}
 TerrainMaterials.__index = TerrainMaterials
-TerrainMaterials.VERSION = "1.0.0"
+TerrainMaterials.VERSION = "1.1.0"
 
 -- Constants
 local DEFAULT_RESOLUTION = 4 -- Studs per terrain voxel
@@ -159,9 +159,17 @@ function TerrainMaterials:applyToRegion(minX: number, maxX: number, minZ: number
 
     local startTime = tick()
     local cellCount = 0
+    local skippedRiverCells = 0
 
     for x = minX, maxX, self.resolution do
         for z = minZ, maxZ, self.resolution do
+            -- CRITICAL: Skip cells that are inside the river corridor
+            -- This prevents overwriting the water terrain placed by RiverBuilder
+            if self.worldPlan and self.worldPlan:isOnRiver(x, z) then
+                skippedRiverCells = skippedRiverCells + 1
+                continue
+            end
+
             local material = self:getMaterialAt(x, z)
             local height = TerrainUtils.getHeightAt(self.terrain, x, z)
 
@@ -191,8 +199,8 @@ function TerrainMaterials:applyToRegion(minX: number, maxX: number, minZ: number
     end
 
     local elapsed = tick() - startTime
-    print(string.format("[TerrainMaterials v%s] Applied materials to %d cells in %.2f seconds",
-        TerrainMaterials.VERSION, cellCount, elapsed))
+    print(string.format("[TerrainMaterials v%s] Applied materials to %d cells in %.2f seconds (skipped %d river cells)",
+        TerrainMaterials.VERSION, cellCount, elapsed, skippedRiverCells))
 end
 
 -- Apply materials to the entire map


### PR DESCRIPTION
Closes #113

## Summary
The river had no visible water despite RiverBuilder correctly filling it with water terrain. The root cause was that `TerrainMaterials.applyToRegion()` runs **after** `RiverBuilder.build()` and was overwriting the water terrain with regular surface materials.

## Root Cause
1. `RiverBuilder:build()` creates walls, clears terrain, and fills with water ✅
2. `TerrainMaterials:applyAll()` runs afterward and iterates over the entire map
3. For each cell, it fills a 4x4x4 block at the terrain surface height
4. It had no check to skip cells inside the river corridor
5. This overwrote the water terrain with grass/rock/sand materials

## Fix
Added a check in `TerrainMaterials:applyToRegion()` to skip cells that are inside the river corridor using `worldPlan:isOnRiver(x, z)`. This preserves the water terrain placed by RiverBuilder.

## Changes
- `src/server/TerrainMaterials.luau`:
  - Add `isOnRiver` check before applying terrain materials
  - Skip river cells to preserve water terrain
  - Log number of skipped river cells for debugging
  - Bump version to 1.1.0

## Test Plan
1. Start Roblox Studio with `rojo serve`
2. Run the game - the river should now be visibly filled with water
3. Water should span the full length and width of the river channel
4. Water depth should be 8-12 studs (visible swimming depth)

## Checklist
- [x] ModuleScripts use .luau extension
- [x] Entry point already requires/initializes module
- [x] No auto-executing code in ModuleScripts
- [x] Objects adapt to terrain height
- [x] Follows BRicey module pattern
- [x] Tests pass (239/239)