### PR TITLE
Fix #114: Prevent urban areas and fountains on steep cliffs

### DIFF
--- a/src/server/WaterFeatures.luau
+++ b/src/server/WaterFeatures.luau
@@ -15,7 +15,7 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local WaterFeatures = {}
 WaterFeatures.__index = WaterFeatures
-WaterFeatures.VERSION = "2.0.0"
+WaterFeatures.VERSION = "2.1.0"
 
 -- Import WaterPool module (same folder)
 local WaterPool = require(script.Parent.WaterPool)
@@ -36,6 +36,7 @@ export type WaterFeaturesInstance = typeof(setmetatable(
         terrainUtils: any,
         terrain: Terrain,
         fountainConfig: any,
+        constants: any,
     },
     WaterFeatures
 ))
@@ -47,6 +48,7 @@ function WaterFeatures.new(config: WaterFeaturesConfig?): WaterFeaturesInstance
     local Shared = ReplicatedStorage:WaitForChild("Shared")
     local TerrainUtils = require(Shared:WaitForChild("TerrainUtils"))
     local FountainConfig = require(Shared:WaitForChild("FountainConfig"))
+    local Constants = require(Shared:WaitForChild("Constants"))
 
     local self = setmetatable({}, WaterFeatures)
     self.config = config or {}
@@ -55,6 +57,7 @@ function WaterFeatures.new(config: WaterFeaturesConfig?): WaterFeaturesInstance
     self.terrainUtils = TerrainUtils
     self.terrain = workspace.Terrain
     self.fountainConfig = FountainConfig
+    self.constants = Constants
 
     print(string.format("[WaterFeatures v%s] Initializing...", WaterFeatures.VERSION))
     return self
@@ -80,20 +83,43 @@ end
 
 function WaterFeatures:_createAllFountains()
     local FountainConfig = self.fountainConfig
+    local TerrainUtils = self.terrainUtils
+    local Constants = self.constants
 
     -- Get placements (custom or default)
     local placements = self.config.customFountainPlacements or FountainConfig.getDefaultPlacements()
+    local maxFountainSlope = Constants.SLOPE.MAX_FOUNTAIN_SLOPE
+    local sampleDistance = Constants.SLOPE.SAMPLE_DISTANCE
 
-    print(string.format("[WaterFeatures v%s] Creating %d fountains...", WaterFeatures.VERSION, #placements))
+    print(string.format("[WaterFeatures v%s] Evaluating %d fountain placements...", WaterFeatures.VERSION, #placements))
 
+    local skippedCount = 0
     for _, placement in ipairs(placements) do
-        self:_createFountain(placement)
+        local x, z = placement.position.X, placement.position.Z
+        local isFlatEnough = TerrainUtils.isFlatEnoughDegrees(self.terrain, x, z, maxFountainSlope, sampleDistance)
+
+        if isFlatEnough then
+            self:_createFountain(placement)
+        else
+            local slope = TerrainUtils.getMaxSlopeDegrees(self.terrain, x, z, sampleDistance)
+            print(string.format(
+                "[WaterFeatures v%s] Skipping fountain '%s' at (%.0f, %.0f) - slope %.1f° exceeds max %.0f°",
+                WaterFeatures.VERSION,
+                placement.name or "unnamed",
+                x,
+                z,
+                slope,
+                maxFountainSlope
+            ))
+            skippedCount = skippedCount + 1
+        end
     end
 
     print(string.format(
-        "[WaterFeatures v%s] Created %d fountains across map",
+        "[WaterFeatures v%s] Created %d fountains, skipped %d due to steep terrain",
         WaterFeatures.VERSION,
-        #self.fountainPools
+        #self.fountainPools,
+        skippedCount
     ))
 end
 

--- a/src/server/WorldPlanGenerator.luau
+++ b/src/server/WorldPlanGenerator.luau
@@ -10,10 +10,11 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local Shared = ReplicatedStorage:WaitForChild("Shared")
 local WorldPlan = require(Shared:WaitForChild("WorldPlan"))
+local Constants = require(Shared:WaitForChild("Constants"))
 
 local WorldPlanGenerator = {}
 WorldPlanGenerator.__index = WorldPlanGenerator
-WorldPlanGenerator.VERSION = "1.0.0"
+WorldPlanGenerator.VERSION = "1.1.0"
 
 export type WorldPlanGeneratorConfig = {
     mapSize: number?,
@@ -21,6 +22,7 @@ export type WorldPlanGeneratorConfig = {
     riverWidth: number?,
     urbanRadius: number?,
     civicRadius: number?,
+    riverCliffMargin: number?, -- Extra margin around river to avoid cliff edges
 }
 
 export type WorldPlanGeneratorInstance = typeof(setmetatable(
@@ -31,6 +33,7 @@ export type WorldPlanGeneratorInstance = typeof(setmetatable(
         riverWidth: number,
         urbanRadius: number,
         civicRadius: number,
+        riverCliffMargin: number,
     },
     WorldPlanGenerator
 ))
@@ -52,6 +55,7 @@ function WorldPlanGenerator.new(config: WorldPlanGeneratorConfig?): WorldPlanGen
     self.riverWidth = cfg.riverWidth or DEFAULT_RIVER_WIDTH
     self.urbanRadius = cfg.urbanRadius or DEFAULT_URBAN_RADIUS
     self.civicRadius = cfg.civicRadius or DEFAULT_CIVIC_RADIUS
+    self.riverCliffMargin = cfg.riverCliffMargin or Constants.SLOPE.RIVER_CLIFF_MARGIN
 
     print(string.format("[WorldPlanGenerator v%s] Initializing with seed: %d", WorldPlanGenerator.VERSION, self.seed))
     return self
@@ -291,14 +295,20 @@ function WorldPlanGenerator.generate(self: WorldPlanGeneratorInstance): WorldPla
     local roads = self:_generateRoads()
     local playerPlots = self:_generatePlayerPlots()
 
+    -- Calculate river exclusion zone (river width + cliff margin on each side)
+    local riverExclusionWidth = self.riverWidth + (self.riverCliffMargin * 2)
+
     local planData: WorldPlan.WorldPlanData = {
         riverPath = riverPath,
         riverWidth = self.riverWidth,
+        riverExclusionWidth = riverExclusionWidth,
         zones = zones,
         landmarks = landmarks,
         roads = roads,
         playerPlots = playerPlots,
         mapSize = self.mapSize,
+        maxUrbanSlope = Constants.SLOPE.MAX_URBAN_SLOPE,
+        maxFountainSlope = Constants.SLOPE.MAX_FOUNTAIN_SLOPE,
     }
 
     local worldPlan = WorldPlan.new(planData)
@@ -312,6 +322,12 @@ function WorldPlanGenerator.generate(self: WorldPlanGeneratorInstance): WorldPla
         #landmarks,
         #roads,
         #playerPlots
+    ))
+    print(string.format("[WorldPlanGenerator v%s] River exclusion zone: %.0f studs (river: %.0f + margins: %.0f)",
+        WorldPlanGenerator.VERSION,
+        riverExclusionWidth,
+        self.riverWidth,
+        self.riverCliffMargin * 2
     ))
 
     return worldPlan

--- a/src/shared/Constants.luau
+++ b/src/shared/Constants.luau
@@ -125,4 +125,13 @@ Constants.AI = {
     LOSE_INTEREST_TIME = 10,
 }
 
+-- Terrain slope constraints for placement
+-- Slopes are in degrees for readability
+Constants.SLOPE = {
+    MAX_URBAN_SLOPE = 30, -- Urban zones should avoid terrain steeper than 30 degrees
+    MAX_FOUNTAIN_SLOPE = 20, -- Fountains need flatter ground (max 20 degrees)
+    RIVER_CLIFF_MARGIN = 30, -- Extra margin around river to avoid cliff edges
+    SAMPLE_DISTANCE = 4, -- Distance to sample terrain for slope calculation
+}
+
 return Constants

--- a/src/shared/TerrainUtils.luau
+++ b/src/shared/TerrainUtils.luau
@@ -111,6 +111,24 @@ function TerrainUtils.isFlatEnough(terrain: Terrain, x: number, z: number, maxSl
     return math.abs(slopeX) <= maxSlopeRadians and math.abs(slopeZ) <= maxSlopeRadians
 end
 
+--- Check if terrain at a position is flat enough for building (slope in degrees)
+--- More convenient API using degrees instead of radians
+function TerrainUtils.isFlatEnoughDegrees(terrain: Terrain, x: number, z: number, maxSlopeDegrees: number, sampleDistance: number?): boolean
+    local dist = sampleDistance or DEFAULT_SAMPLE_DISTANCE
+    local slopeX, slopeZ = TerrainUtils.getSlopeXZ(terrain, x, z, dist)
+    local maxSlopeRadians = math.rad(maxSlopeDegrees)
+    return math.abs(slopeX) <= maxSlopeRadians and math.abs(slopeZ) <= maxSlopeRadians
+end
+
+--- Get the maximum slope (in degrees) at a position
+--- Returns the steeper of X and Z slopes
+function TerrainUtils.getMaxSlopeDegrees(terrain: Terrain, x: number, z: number, sampleDistance: number?): number
+    local dist = sampleDistance or DEFAULT_SAMPLE_DISTANCE
+    local slopeX, slopeZ = TerrainUtils.getSlopeXZ(terrain, x, z, dist)
+    local maxSlopeRadians = math.max(math.abs(slopeX), math.abs(slopeZ))
+    return math.deg(maxSlopeRadians)
+end
+
 --- Get the average height across multiple sample points
 function TerrainUtils.getAverageHeight(terrain: Terrain, x: number, z: number, radius: number, samples: number?): number
     local numSamples = samples or 4

--- a/src/shared/WorldPlan.luau
+++ b/src/shared/WorldPlan.luau
@@ -13,7 +13,7 @@
 
 local WorldPlan = {}
 WorldPlan.__index = WorldPlan
-WorldPlan.VERSION = "1.0.0"
+WorldPlan.VERSION = "1.1.0"
 
 -- Type definitions for the world plan data
 export type ZoneType = "urban" | "rural" | "civic" | "wilderness"
@@ -53,6 +53,7 @@ export type WorldPlanData = {
     -- River path (source of truth for water)
     riverPath: { Vector2 },
     riverWidth: number,
+    riverExclusionWidth: number?, -- Width including cliff margins for urban placement
 
     -- Zones (source of truth for urban/rural)
     zones: { Zone },
@@ -68,6 +69,10 @@ export type WorldPlanData = {
 
     -- Map dimensions
     mapSize: number,
+
+    -- Slope constraints for placement validation
+    maxUrbanSlope: number?, -- Max slope (degrees) for urban zones
+    maxFountainSlope: number?, -- Max slope (degrees) for fountains
 }
 
 export type WorldPlanInstance = typeof(setmetatable(
@@ -152,6 +157,30 @@ end
 function WorldPlan.getDistanceToRiver(self: WorldPlanInstance, x: number, z: number): number
     local point = Vector2.new(x, z)
     return distanceToPath(point, self.data.riverPath)
+end
+
+-- Check if position is in the river cliff exclusion zone (river + cliff margins)
+-- Used to prevent urban placement on steep terrain near river
+function WorldPlan.isInRiverExclusionZone(self: WorldPlanInstance, x: number, z: number): boolean
+    local point = Vector2.new(x, z)
+    local distance = distanceToPath(point, self.data.riverPath)
+    local exclusionWidth = self.data.riverExclusionWidth or self.data.riverWidth
+    return distance <= (exclusionWidth / 2)
+end
+
+-- Get the river exclusion width (river + cliff margins)
+function WorldPlan.getRiverExclusionWidth(self: WorldPlanInstance): number
+    return self.data.riverExclusionWidth or self.data.riverWidth
+end
+
+-- Get the max slope for urban placement (in degrees)
+function WorldPlan.getMaxUrbanSlope(self: WorldPlanInstance): number
+    return self.data.maxUrbanSlope or 30 -- Default 30 degrees
+end
+
+-- Get the max slope for fountain placement (in degrees)
+function WorldPlan.getMaxFountainSlope(self: WorldPlanInstance): number
+    return self.data.maxFountainSlope or 20 -- Default 20 degrees
 end
 
 -- Zone queries
@@ -291,12 +320,12 @@ end
 
 -- Combined queries
 function WorldPlan.canPlaceStructure(self: WorldPlanInstance, x: number, z: number, size: Vector2): (boolean, string?)
-    -- Check if position is on river
-    if self:isOnRiver(x, z) then
-        return false, "Cannot place on river"
+    -- Check if position is in river exclusion zone (includes cliff margins)
+    if self:isInRiverExclusionZone(x, z) then
+        return false, "Cannot place near river cliffs"
     end
 
-    -- Check corners and center for river collision
+    -- Check corners and center for river exclusion zone collision
     local halfSize = size / 2
     local checkPoints = {
         Vector2.new(x - halfSize.X, z - halfSize.Y),
@@ -306,8 +335,8 @@ function WorldPlan.canPlaceStructure(self: WorldPlanInstance, x: number, z: numb
     }
 
     for _, point in ipairs(checkPoints) do
-        if self:isOnRiver(point.X, point.Y) then
-            return false, "Structure would overlap river"
+        if self:isInRiverExclusionZone(point.X, point.Y) then
+            return false, "Structure would overlap river exclusion zone"
         end
     end
 

--- a/tests/shared/Constants.spec.luau
+++ b/tests/shared/Constants.spec.luau
@@ -85,5 +85,26 @@ return function(describe: DescribeFn, it: ItFn, expect: ExpectFn)
             expect(Constants.AI.PATROL_SPEED).to.be.ok()
             expect(Constants.AI.DETECTION_RANGE).to.be.ok()
         end)
+
+        it("should have SLOPE constraints", function()
+            expect(Constants.SLOPE).to.be.ok()
+            expect(Constants.SLOPE.MAX_URBAN_SLOPE).to.be.ok()
+            expect(type(Constants.SLOPE.MAX_URBAN_SLOPE)).to.equal("number")
+            expect(Constants.SLOPE.MAX_FOUNTAIN_SLOPE).to.be.ok()
+            expect(type(Constants.SLOPE.MAX_FOUNTAIN_SLOPE)).to.equal("number")
+            expect(Constants.SLOPE.RIVER_CLIFF_MARGIN).to.be.ok()
+            expect(type(Constants.SLOPE.RIVER_CLIFF_MARGIN)).to.equal("number")
+            expect(Constants.SLOPE.SAMPLE_DISTANCE).to.be.ok()
+            expect(type(Constants.SLOPE.SAMPLE_DISTANCE)).to.equal("number")
+        end)
+
+        it("should have appropriate slope values", function()
+            -- Urban slope should be greater than fountain slope
+            expect(Constants.SLOPE.MAX_URBAN_SLOPE).to.be.greaterThan(Constants.SLOPE.MAX_FOUNTAIN_SLOPE)
+            -- Fountain slope should be at most 20 degrees
+            expect(Constants.SLOPE.MAX_FOUNTAIN_SLOPE).to.equal(20)
+            -- Urban slope should be at most 30 degrees
+            expect(Constants.SLOPE.MAX_URBAN_SLOPE).to.equal(30)
+        end)
     end)
 end

--- a/tests/shared/TerrainUtils.spec.luau
+++ b/tests/shared/TerrainUtils.spec.luau
@@ -47,5 +47,13 @@ return function(describe: DescribeFn, it: ItFn, expect: ExpectFn)
         it("should export getAverageHeight function", function()
             expect(type(TerrainUtils.getAverageHeight)).to.equal("function")
         end)
+
+        it("should export isFlatEnoughDegrees function", function()
+            expect(type(TerrainUtils.isFlatEnoughDegrees)).to.equal("function")
+        end)
+
+        it("should export getMaxSlopeDegrees function", function()
+            expect(type(TerrainUtils.getMaxSlopeDegrees)).to.equal("function")
+        end)
     end)
 end

--- a/tests/shared/WorldPlan.spec.luau
+++ b/tests/shared/WorldPlan.spec.luau
@@ -50,6 +50,22 @@ describe("WorldPlan", function()
         expect(string.find(moduleSource, "function WorldPlan.getDistanceToRiver", 1, true)).toNotBeNil()
     end)
 
+    it("should have isInRiverExclusionZone() method", function()
+        expect(string.find(moduleSource, "function WorldPlan.isInRiverExclusionZone", 1, true)).toNotBeNil()
+    end)
+
+    it("should have getRiverExclusionWidth() method", function()
+        expect(string.find(moduleSource, "function WorldPlan.getRiverExclusionWidth", 1, true)).toNotBeNil()
+    end)
+
+    it("should have getMaxUrbanSlope() method", function()
+        expect(string.find(moduleSource, "function WorldPlan.getMaxUrbanSlope", 1, true)).toNotBeNil()
+    end)
+
+    it("should have getMaxFountainSlope() method", function()
+        expect(string.find(moduleSource, "function WorldPlan.getMaxFountainSlope", 1, true)).toNotBeNil()
+    end)
+
     -- Zone query interface
     it("should have getZoneAt() method", function()
         expect(string.find(moduleSource, "function WorldPlan.getZoneAt", 1, true)).toNotBeNil()
@@ -146,6 +162,18 @@ describe("WorldPlan", function()
 
     it("should export WorldPlanData type", function()
         expect(string.find(moduleSource, "export type WorldPlanData", 1, true)).toNotBeNil()
+    end)
+
+    it("should have riverExclusionWidth in WorldPlanData type", function()
+        expect(string.find(moduleSource, "riverExclusionWidth", 1, true)).toNotBeNil()
+    end)
+
+    it("should have maxUrbanSlope in WorldPlanData type", function()
+        expect(string.find(moduleSource, "maxUrbanSlope", 1, true)).toNotBeNil()
+    end)
+
+    it("should have maxFountainSlope in WorldPlanData type", function()
+        expect(string.find(moduleSource, "maxFountainSlope", 1, true)).toNotBeNil()
     end)
 
     it("should export WorldPlanInstance type", function()


### PR DESCRIPTION
Closes #114

## Summary
- Adds slope validation to prevent fountains from being placed on terrain steeper than 20 degrees
- Adds river exclusion zone that includes cliff margins to prevent urban zone placements near steep river banks
- Introduces configurable slope constants for consistent placement validation across the codebase

## Changes
- `src/shared/Constants.luau`: Added SLOPE constants (MAX_URBAN_SLOPE=30°, MAX_FOUNTAIN_SLOPE=20°, RIVER_CLIFF_MARGIN=30 studs, SAMPLE_DISTANCE=4)
- `src/shared/TerrainUtils.luau`: Added isFlatEnoughDegrees() and getMaxSlopeDegrees() helper functions
- `src/shared/WorldPlan.luau`: Added isInRiverExclusionZone(), getRiverExclusionWidth(), getMaxUrbanSlope(), getMaxFountainSlope() methods; updated canPlaceStructure() to check river exclusion zone
- `src/server/WorldPlanGenerator.luau`: Now includes riverExclusionWidth and slope constraints in generated plan data
- `src/server/WaterFeatures.luau`: Validates terrain slope before creating fountains, skips placements exceeding MAX_FOUNTAIN_SLOPE
- `tests/shared/Constants.spec.luau`: Added tests for SLOPE constants
- `tests/shared/TerrainUtils.spec.luau`: Added tests for new slope functions
- `tests/shared/WorldPlan.spec.luau`: Added tests for new methods

## BRicey Pattern Checklist
- [x] ModuleScripts use .luau extension
- [x] Entry point updated to require/initialize module
- [x] No auto-executing code in ModuleScripts
- [x] ModuleScripts return their table

🤖 Generated with [Claude Code](https://claude.com/claude-code)