### PR TITLE
Implement #127: Add river exclusion validation to LandmarkBuilder

### DIFF
--- a/src/server/LandmarkBuilder.luau
+++ b/src/server/LandmarkBuilder.luau
@@ -20,7 +20,7 @@ local WorldPlan = require(Shared:WaitForChild("WorldPlan"))
 
 local LandmarkBuilder = {}
 LandmarkBuilder.__index = LandmarkBuilder
-LandmarkBuilder.VERSION = "1.0.0"
+LandmarkBuilder.VERSION = "1.1.0"
 
 -- Roman architectural colors
 local MARBLE_WHITE = Color3.fromRGB(240, 235, 225)
@@ -1051,15 +1051,31 @@ function LandmarkBuilder:build(): Folder
     local landmarks = self.worldPlan:getLandmarks()
 
     -- Build each landmark
+    local skippedCount = 0
     for i, landmark in ipairs(landmarks) do
+        local x = landmark.position.X
+        local z = landmark.position.Y -- Vector2 Y is world Z
+
+        -- Validate: skip landmarks in river exclusion zone
+        if self.worldPlan:isInRiverExclusionZone(x, z) then
+            warn(string.format("[LandmarkBuilder v%s] Skipping %s at (%.1f, %.1f) - in river exclusion zone",
+                LandmarkBuilder.VERSION,
+                landmark.landmarkType,
+                x,
+                z
+            ))
+            skippedCount = skippedCount + 1
+            continue
+        end
+
         local landmarkFolder = Instance.new("Folder")
         landmarkFolder.Name = string.format("%s_%d", landmark.landmarkType, i)
         landmarkFolder.Parent = folder
 
         self:_buildLandmarkByType(
             landmark.landmarkType,
-            landmark.position.X,
-            landmark.position.Y,
+            x,
+            z,
             landmark.radius,
             landmarkFolder
         )
@@ -1069,8 +1085,8 @@ function LandmarkBuilder:build(): Folder
         print(string.format("[LandmarkBuilder v%s] Built %s at (%.1f, %.1f)",
             LandmarkBuilder.VERSION,
             landmark.landmarkType,
-            landmark.position.X,
-            landmark.position.Y
+            x,
+            z
         ))
 
         -- Yield periodically to avoid script timeout
@@ -1080,11 +1096,12 @@ function LandmarkBuilder:build(): Folder
     end
 
     local elapsed = tick() - startTime
-    print(string.format("[LandmarkBuilder v%s] Built %d landmarks in %.2f seconds (%d parts)",
+    print(string.format("[LandmarkBuilder v%s] Built %d landmarks in %.2f seconds (%d parts, %d skipped for river)",
         LandmarkBuilder.VERSION,
         self.landmarkCount,
         elapsed,
-        #self.parts
+        #self.parts,
+        skippedCount
     ))
 
     return folder

--- a/tests/server/LandmarkBuilder.spec.luau
+++ b/tests/server/LandmarkBuilder.spec.luau
@@ -190,6 +190,29 @@ describe("LandmarkBuilder", function()
         expect(string.find(moduleSource, "TerrainUtils.getHeightAt", 1, true)).toNotBeNil()
     end)
 
+    -- River exclusion zone validation
+    it("should check river exclusion zone before building landmarks", function()
+        expect(string.find(moduleSource, "isInRiverExclusionZone", 1, true)).toNotBeNil()
+    end)
+
+    it("should skip landmarks in river exclusion zone", function()
+        -- Should have continue statement to skip invalid landmarks
+        expect(string.find(moduleSource, "in river exclusion zone", 1, true)).toNotBeNil()
+    end)
+
+    it("should warn when skipping landmarks in river exclusion zone", function()
+        -- Should use warn() for skipped landmarks
+        expect(string.find(moduleSource, "warn(string.format", 1, true)).toNotBeNil()
+    end)
+
+    it("should track skipped landmark count", function()
+        expect(string.find(moduleSource, "skippedCount", 1, true)).toNotBeNil()
+    end)
+
+    it("should report skipped landmarks in final summary", function()
+        expect(string.find(moduleSource, "skipped for river", 1, true)).toNotBeNil()
+    end)
+
     it("should not have auto-executing code at module end", function()
         -- Check that module ends with return statement, not function calls
         local lines = {}


### PR DESCRIPTION
Closes #127

## Summary
- Added river exclusion zone validation in `LandmarkBuilder:build()` loop
- Landmarks that fall within the river exclusion zone are now skipped with a warning
- Existing placement logic is preserved; only validation was added

## Changes
- `src/server/LandmarkBuilder.luau`:
  - Bumped VERSION to 1.1.0
  - Added `isInRiverExclusionZone(x, z)` check before building each landmark
  - Added `skippedCount` tracking and warning logs for skipped landmarks
  - Updated final summary to report skipped count

- `tests/server/LandmarkBuilder.spec.luau`:
  - Added 5 new tests for river exclusion validation

## Test Plan
1. Run `lune run tests/init.luau` - all 501 tests pass
2. In Roblox Studio, verify landmarks still build normally
3. If a landmark position were in the river exclusion zone, verify warning appears in Output

## Checklist
- [x] ModuleScripts use .luau extension
- [x] No auto-executing code in ModuleScripts
- [x] Objects adapt to terrain height (existing behavior preserved)
- [x] Follows BRicey module pattern
- [x] Tests written and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)